### PR TITLE
fix for #1 : changes to name as per bower naming convention

### DIFF
--- a/Part-002/bower.json
+++ b/Part-002/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-002",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-003/bower.json
+++ b/Part-003/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-003",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-004/bower.json
+++ b/Part-004/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-004",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-005/bower.json
+++ b/Part-005/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-005",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-006/bower.json
+++ b/Part-006/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-006",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-007/bower.json
+++ b/Part-007/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-007",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-008/bower.json
+++ b/Part-008/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-008",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-009/bower.json
+++ b/Part-009/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-009",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-010/bower.json
+++ b/Part-010/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-010",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-015/bower.json
+++ b/Part-015/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-015",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-016/bower.json
+++ b/Part-016/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-016",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-017/bower.json
+++ b/Part-017/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-017",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-018/bower.json
+++ b/Part-018/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-018",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-021/bower.json
+++ b/Part-021/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-021",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [

--- a/Part-024/bower.json
+++ b/Part-024/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Part-002",
+  "name": "part-024",
   "version": "1.0.0",
   "main": "path/to/main.css",
   "ignore": [


### PR DESCRIPTION
Pull  request for issue #1 - Follow bower naming conventions in the bower.json 
- Changed name to slug style
-  all bower.json files had Part-02 as name. Changed to their respective name according to the folder.
